### PR TITLE
adds module.exports to main file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require('./lib/postcss-pipeline-webpack-plugin');
+module.exports = require('./lib/postcss-pipeline-webpack-plugin');


### PR DESCRIPTION
This plugin is great, but I have to require using `require('postcss-pipeline-webpack-plugin/lib/postcss-pipeline-webpack-plugin')` currently because the main file is missing module.exports...This PR adds that!