### PR TITLE
allow undefined suffix to skip rename

### DIFF
--- a/lib/postcss-pipeline-webpack-plugin.js
+++ b/lib/postcss-pipeline-webpack-plugin.js
@@ -40,7 +40,7 @@ PostCssPipelineWebpackPlugin.prototype.generate = function (compilation) {
         ))
         .map(name => ({
           from: name,
-          to: name.replace(MASK, '.' + suffix + '.css'),
+          to: suffix !== undefined ? name.replace(MASK, '.' + suffix + '.css') : name,
           map
         }))
         .map(options => (

--- a/lib/postcss-pipeline-webpack-plugin.js
+++ b/lib/postcss-pipeline-webpack-plugin.js
@@ -40,7 +40,7 @@ PostCssPipelineWebpackPlugin.prototype.generate = function (compilation) {
         ))
         .map(name => ({
           from: name,
-          to: suffix !== undefined ? name.replace(MASK, '.' + suffix + '.css') : name,
+          to: suffix ? name.replace(MASK, '.' + suffix + '.css') : name,
           map
         }))
         .map(options => (

--- a/test/spec.js
+++ b/test/spec.js
@@ -69,6 +69,26 @@ describe('PostCss Pipeline Webpack Plugin', function () {
       });
   });
 
+  it('should generate properly named files when sufix is undefined', function () {
+    const plugin = new PostCssPipelineWebpackPlugin({
+      suffix: undefined
+    });
+
+    return plugin
+      .generate({
+        assets: {
+          './styles.css': new RawSource('')
+        }
+      })
+      .then(compilation => {
+        const keys = Object.keys(compilation.assets);
+
+        assert.deepStrictEqual(keys, [
+          './styles.css'
+        ]);
+      });
+  });
+
   it('should filter files to process', function () {
     const plugin = new PostCssPipelineWebpackPlugin({
       predicate: name => /foobar.css$/.test(name)


### PR DESCRIPTION
This allows for you to define the plugin with an undefined suffix and have it skip the rename process. eg:

```
new PostCssPipelineWebpackPlugin({
    suffix: undefined
});
```