### PR TITLE
External sourcemap enhancement

### DIFF
--- a/lib/postcss-pipeline-webpack-plugin.js
+++ b/lib/postcss-pipeline-webpack-plugin.js
@@ -38,11 +38,21 @@ PostCssPipelineWebpackPlugin.prototype.generate = function (compilation) {
         .filter(k => (
           MASK.test(k) && predicate(k)
         ))
-        .map(name => ({
-          from: name,
-          to: suffix ? name.replace(MASK, '.' + suffix + '.css') : name,
-          map
-        }))
+        .map(name => {
+          // check if external sourcemap file exists
+          const prevMap = compilation.assets[name + '.map'];
+          if (prevMap) {
+            // define previous map for postcss to use
+            if (map) map.prev = prevMap.source();
+            else map = { prev: prevMap.source() }
+          }
+
+          return {
+            from: name,
+            to: suffix ? name.replace(MASK, '.' + suffix + '.css') : name,
+            map
+          }
+        })
         .map(options => (
           postcss(pipeline)
             .process(compilation.assets[options.from].source(), options)

--- a/lib/postcss-pipeline-webpack-plugin.js
+++ b/lib/postcss-pipeline-webpack-plugin.js
@@ -41,16 +41,16 @@ PostCssPipelineWebpackPlugin.prototype.generate = function (compilation) {
         .map(name => {
           // check if external sourcemap file exists
           const prevMap = compilation.assets[name + '.map'];
+          let mapOpt = Object.assign({}, map);
+          // define previous map for postcss to use
           if (prevMap) {
-            // define previous map for postcss to use
-            if (map) map.prev = prevMap.source();
-            else map = { prev: prevMap.source() }
+            mapOpt.prev = prevMap.source();
           }
 
           return {
             from: name,
             to: suffix ? name.replace(MASK, '.' + suffix + '.css') : name,
-            map
+            map: mapOpt
           }
         })
         .map(options => (

--- a/lib/postcss-pipeline-webpack-plugin.js
+++ b/lib/postcss-pipeline-webpack-plugin.js
@@ -39,12 +39,13 @@ PostCssPipelineWebpackPlugin.prototype.generate = function (compilation) {
           MASK.test(k) && predicate(k)
         ))
         .map(name => {
-          // check if external sourcemap file exists
           const prevMap = compilation.assets[name + '.map'];
-          let mapOpt = Object.assign({}, map);
+          var mapOpt = map;
+
+          // check if external sourcemap file exists
           // define previous map for postcss to use
           if (prevMap) {
-            mapOpt.prev = prevMap.source();
+            mapOpt =  Object.assign({ prev: prevMap.source() }, map);
           }
 
           return {


### PR DESCRIPTION
I noticed that source maps were not fully resolving when using this plugin with project using `@import` to import component modules.

This PR makes a change to pass the previously created sourcemap (if it exists) to the map option for postcss, so it can figure out how to resolve imported modules. 

This still passes tests locally, but I'm not sure exactly how we test that with the fixtures in place. point me in the right direction 🍖 