### PR TITLE
added prefix option

### DIFF
--- a/lib/postcss-pipeline-webpack-plugin.js
+++ b/lib/postcss-pipeline-webpack-plugin.js
@@ -5,7 +5,8 @@ const MASK = /\.css(\?.+)?$/;
 
 /**
  * @param {Function} options.predicate is a function invoked per CSS file
- * @param {String} options.suffix is a string attached to the new file
+ * @param {String} options.suffix is a string attached to the end of a new file ie: style.suffix.css (Defaults to 'processed')
+ * @param {String} options.prefix is a string attached to the beginning of a new file ie: prefix.style.css (Overrides Suffix)
  * @param {Array} options.pipeline is a list of PostCSS plugins
  * @param {Object} options.map is a PostCSS source maps configuration
  */
@@ -13,6 +14,7 @@ function PostCssPipelineWebpackPlugin(options) {
   this._options = Object.assign({
     predicate: () => true,
     suffix: 'processed',
+    prefix: '',
     pipeline: []
   }, options);
 }
@@ -25,6 +27,7 @@ PostCssPipelineWebpackPlugin.prototype.generate = function (compilation) {
   const _options = this._options;
   const predicate = _options.predicate;
   const suffix = _options.suffix;
+  const prefix = _options.prefix;
   const pipeline = _options.pipeline;
   const map = _options.map;
 
@@ -36,10 +39,11 @@ PostCssPipelineWebpackPlugin.prototype.generate = function (compilation) {
         ))
         .map(name => {
           const prevMap = compilation.assets[name + '.map'];
+          const css_path = name.substring(0, name.lastIndexOf("/")) + '/';
 
           return {
             from: name,
-            to: suffix ? name.replace(MASK, match => '.' + suffix + match) : name,
+            to: prefix ? name.replace(css_path, match => match + prefix + '.') : suffix ? name.replace(MASK, match => '.' + suffix + match) : name,
             map: prevMap ? Object.assign({prev: prevMap.source()}, map) : map
           }
         })


### PR DESCRIPTION
Hi not sure if this would be beneficial in other scenarios, but for me when using postcss-critical-split (like in your example) the default functionality added the suffix after webpack's applied hash. For my purposes though, I needed it to come before, so, I added the option for a prefix too. If prefix is defined, it will override the suffix (if it is defined), but suffix still defaults to 'processed' if neither are defined.

before this PR, the following resulted in something like **/css/styles-025c18f3.critical.css**
```
plugins: [
    new MiniCssExtractPlugin({
      filename: "css/[name]-[hash:8].css"
    }),
    new PostCssPipelineWebpackPlugin({
      suffix: 'critical',
      pipeline: [
        criticalSplit({
          output: criticalSplit.output_types.CRITICAL_CSS
        })
      ]
    })
]
```

but with this PR the following would result in **/css/critical.styles-025c18f3.css**

```
plugins: [
    new MiniCssExtractPlugin({
      filename: "css/[name]-[hash:8].css"
    }),
    new PostCssPipelineWebpackPlugin({
      prefix: 'critical',
      pipeline: [
        criticalSplit({
          output: criticalSplit.output_types.CRITICAL_CSS
        })
      ]
    })
]
```